### PR TITLE
Disable HTTP/2 as workaround for nginx bug

### DIFF
--- a/simplepush.go
+++ b/simplepush.go
@@ -7,6 +7,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha1"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -15,6 +16,12 @@ import (
 	"net/http"
 	"net/url"
 )
+
+func init() {
+	// Disable HTTP/2 support- see the package overview in net/http docs
+	tr, _ := http.DefaultTransport.(*http.Transport)
+	tr.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
+}
 
 // Message contains all the information necessary to send a, potentially encrypted, message.
 type Message struct {


### PR DESCRIPTION
It appears that the version of nginx running on your production servers has [a bug with HTTP/2](https://github.com/golang/go/issues/17066#issuecomment-246202324). I'm receiving the same error when using the library-

`2017/03/09 19:49:26 Post https://api.simplepush.io/send: stream error: stream ID 1; REFUSED_STREAM`

As a workaround for this, HTTP/2 can be disabled by setting http.Transport.TLSNextProto to a non-nil, empty map. The end of the [net/http package overview](https://golang.org/pkg/net/http/#pkg-overview) gives details on this. Alternatively, nginx could be upgraded- it appears that [nginx 1.11.0 has the necessary fix](https://trac.nginx.org/nginx/ticket/959) though I haven't played with this myself. I can confirm that this does fix the problem when testing against my personal key.

Thanks for putting together the service and library, it's a joy to use.
